### PR TITLE
Remove log from safe free

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -167,10 +167,7 @@ void *safe_malloc(size_t size, int zero)
 
 void safe_free(void *ptr)
 {
-        if (ptr == NULL)
-                r_warn("safe_free: ptr == NULL");
-        else
-                free_wrapper(ptr);
+        free_wrapper(ptr);
 }
 
 void *safe_calloc(size_t nmemb, size_t size)

--- a/test/src/mem_tests.cpp
+++ b/test/src/mem_tests.cpp
@@ -128,17 +128,6 @@ TEST_F(mem_tests, safe_free_frees_ptr_when_ptr)
     ASSERT_EQ(free_wrapper_fake.call_count, 1);
 }
 
-TEST_F(mem_tests, safe_free_warns_when_ptr_NULL)
-{
-    // Arrange
-    // Act
-    safe_free(nullptr);
-
-    // Assert
-    ASSERT_EQ(r_warn_fake.call_count, 1);
-    ASSERT_EQ(free_wrapper_fake.call_count, 0);
-}
-
 TEST_F(mem_tests, safe_calloc_calls_with_correct_size)
 {
     // Arrange


### PR DESCRIPTION
safe_free print a log message when the pointer is NULL. However, passing a NULL pointer is OK. The log messages are becoming a burden.